### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: './dist'
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -142,3 +142,16 @@ npm run preview
 ```
 
 ---
+
+## 🚀 Deploy no GitHub Pages
+
+1. Configure o campo `homepage` no `package.json` com o endereço do seu repositório:
+   `https://seu-usuario.github.io/ascenc-website`.
+2. Instale as dependências e rode o comando de deploy:
+
+```bash
+npm install
+npm run deploy
+```
+
+O workflow `Deploy to GitHub Pages` também publica automaticamente o conteúdo da pasta `dist/` sempre que houver push na branch `main`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
@@ -28,6 +30,8 @@
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
-    "vite": "^7.0.4"
-  }
+    "vite": "^7.0.4",
+    "gh-pages": "^6.0.0"
+  },
+  "homepage": "https://your-username.github.io/ascenc-website"
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,6 @@ import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/ascenc-website/',
   plugins: [react(), tailwindcss()],
 })


### PR DESCRIPTION
## Summary
- configure package.json with gh-pages scripts and homepage
- set base URL for Vite to work on GitHub Pages
- add GitHub Actions workflow for automatic deployment
- document how to deploy manually

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: E403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6887e7f8812c8324a21ffbe479b356f3