### PR TITLE
Fix GH Pages path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: './build' # ou ./dist se você usa Vite
+          path: './dist'
           
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- correct deploy workflow path to use Vite's `dist` directory

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ed30610c8324b636b6a73c3cdf90